### PR TITLE
refactor: refactor bad smell InnerClassMayBeStatic

### DIFF
--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptor.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptor.java
@@ -93,7 +93,7 @@ class StreamInterceptor extends PrintStream {
 		super.write(buf, off, len);
 	}
 
-	class RewindableByteArrayOutputStream extends ByteArrayOutputStream {
+	staticclass RewindableByteArrayOutputStream extends ByteArrayOutputStream {
 
 		private final Deque<Integer> markedPositions = new ArrayDeque<>();
 


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## InnerClassMayBeStatic
Inner classes that do not reference their enclosing instances can be made static.
This prevents a common cause of memory leaks and uses less memory per instance of the class.

<!-- fingerprint:-878205111 -->
# Repairing Code Style Issues
* InnerClassMayBeStatic (1)
